### PR TITLE
fix toggle comment

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -2,7 +2,7 @@
     "comments": {
         // symbol used for single line comment. Remove this entry if your language does not support line comments
         // "lineComment": "//",
-        "lineComment": ["*", ";", "$"]        
+        "lineComment": "*"
         // symbols used for start and end a block comment. Remove this entry if your language does not support block comments
         // "blockComment": [ "/*", "*/" ]
     },

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
         "vscode": "^1.15.0"
     },
     "categories": [
-        "Languages"
+        "Programming Languages"
     ],
     "contributes": {
         "languages": [{


### PR DESCRIPTION
Doesn't seem like you can define multiple comment characters for quick commenting