### PR TITLE
Add snippets for independent voltage/current sources

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,10 @@
             {
                 "language": "spice",
                 "path": "./snippets/snippets_meas.json"
+            },
+            {
+                "language": "spice",
+                "path": "./snippets/snippets_sources.json"
             }
         ]
     }

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -15,6 +15,13 @@
         ],
         "description": "Parameter"
     },
+    "Control": {
+        "prefix": ".con",
+        "body": [
+            ".control\n${1}\n.endc"
+        ],
+        "description": "Control"
+    },
     "Initial Condition": {
         "prefix": ".ic",
         "body": [

--- a/snippets/snippets_sources.json
+++ b/snippets/snippets_sources.json
@@ -1,0 +1,30 @@
+{
+    "Pulse Source": {
+        "prefix": "pulse",
+        "body": [
+            "pulse(${1:intial} ${2:peak} ${3:delay_time} ${4:rise_time} ${5:fall_time} ${6:pulse_width} ${7:period})"
+        ],
+        "description": "PULSE(V1 V2 TD TR TF PW PER PHASE)"
+    },
+    "Sinusoidal Source": {
+        "prefix": "sin",
+        "body": [
+            "sin(${1:offset} ${2:amplitude} ${3:frequency})"
+        ],
+        "description": "SIN(VO VA FREQ TD THETA PHASE)"
+    },
+    "Exponential Source": {
+        "prefix": "exp",
+        "body": [
+            "exp(${1:initial} ${2:pulsed} ${3:rise_delay} ${4:rise_time} ${5:fall_delay} ${6:fall_time})"
+        ],
+        "description": "EXP(V1 V2 TD1 TAU1 TD2 TAU2)"
+    },
+    "Piece-Wise Linear Source": {
+        "prefix": "pwl",
+        "body": [
+            "PWL(T1 V1 <T2 V2 ...>)"
+        ],
+        "description": "Piece-Wise Linear Source"
+    }
+}

--- a/snippets/snippets_sources.json
+++ b/snippets/snippets_sources.json
@@ -23,8 +23,8 @@
     "Piece-Wise Linear Source": {
         "prefix": "pwl",
         "body": [
-            "PWL(T1 V1 <T2 V2 ...>)"
+            "pwl(${1:t1} ${2:v1} ${3:t2} ${4:v2}$0)"
         ],
-        "description": "Piece-Wise Linear Source"
+        "description": "PWL(T1 V1 <T2 V2 ...>)"
     }
 }


### PR DESCRIPTION
Add snippets to help with completing common voltage/current sources.
These are based on Chapter 4 of the Ngspice User's Manual (version 34).

I also add a snippet for .control.